### PR TITLE
Added FoundationNetworking imports for building on Linux

### DIFF
--- a/Sources/SwiftPublicSuffixList/PublicSuffixList.swift
+++ b/Sources/SwiftPublicSuffixList/PublicSuffixList.swift
@@ -11,6 +11,9 @@
 //  Further checks added based on https://docs.microsoft.com/en-us/troubleshoot/windows-server/identity/naming-conventions-for-computer-domain-site-ou
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 final public class PublicSuffixList {
     

--- a/Sources/SwiftPublicSuffixList/PublicSuffixOnlineRegistryFetcher.swift
+++ b/Sources/SwiftPublicSuffixList/PublicSuffixOnlineRegistryFetcher.swift
@@ -7,6 +7,9 @@
 //
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 public class PublicSuffixListOnlineRegistryFetcher {
     


### PR DESCRIPTION
The package fails to build on Linux. Importing FoundationNetworking if available fixes the issue.